### PR TITLE
feat: Enable switching between languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@capacitor/keyboard": "1.0.2",
     "@capacitor/status-bar": "1.0.2",
     "@ionic/angular": "^5.5.2",
+    "@ngx-translate/core": "^14.0.0",
+    "@ngx-translate/http-loader": "^7.0.0",
     "@types/pouchdb": "^6.4.0",
     "angular-cli-ghpages": "^1.0.0-rc.2",
     "date-fns": "^2.23.0",

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,4 +1,4 @@
-<div class="container ion-text-center">
+<div class="ion-text-center">
   <a href="https://github.com/benjamin-hempel/dvbetter" target="_blank"><ion-icon name="logo-github" size="large">GitHub</ion-icon></a>
   <br />
   <ion-text color="medium">{{ 'settings.no-affiliation' | translate }}</ion-text>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,7 +1,5 @@
 <div class="container ion-text-center">
   <a href="https://github.com/benjamin-hempel/dvbetter" target="_blank"><ion-icon name="logo-github" size="large">GitHub</ion-icon></a>
   <br />
-  © {{ currentYear }} Benjamin Hempel
-  <br />
   <ion-text color="medium">{{ 'settings.no-affiliation' | translate }}</ion-text>
 </div>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,0 +1,7 @@
+<div class="container ion-text-center">
+  <a href="https://github.com/benjamin-hempel/dvbetter" target="_blank"><ion-icon name="logo-github" size="large">GitHub</ion-icon></a>
+  <br />
+  © {{ currentYear }} Benjamin Hempel
+  <br />
+  <ion-text color="medium">{{ 'settings.no-affiliation' | translate }}</ion-text>
+</div>

--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -1,0 +1,3 @@
+.container {
+    padding: 16px;
+}

--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -1,3 +1,1 @@
-.container {
-    padding: 16px;
-}
+

--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AboutComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-about',
+  templateUrl: './about.component.html',
+  styleUrls: ['./about.component.scss'],
+})
+export class AboutComponent implements OnInit {
+  currentYear: number = new Date().getFullYear();
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -6,7 +6,6 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./about.component.scss'],
 })
 export class AboutComponent implements OnInit {
-  currentYear: number = new Date().getFullYear();
 
   constructor() { }
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
   },
   {
     path: 'settings',
-    loadChildren: () => import('./settings/settings.module').then( m => m.SettingsPageModule)
+    loadChildren: () => import('./settings/settings.module').then(m => m.SettingsPageModule)
   },
   {
     path: '',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,10 @@ const routes: Routes = [
     loadChildren: () => import('./departures/departures.module').then(m => m.DeparturesPageModule)
   },
   {
+    path: 'settings',
+    loadChildren: () => import('./settings/settings.module').then( m => m.SettingsPageModule)
+  },
+  {
     path: '',
     redirectTo: '/departures',
     pathMatch: 'full'

--- a/src/app/app-title/app-title.component.html
+++ b/src/app/app-title/app-title.component.html
@@ -1,3 +1,3 @@
 <ion-title>
-  <ion-text color="primary">DVB</ion-text>etter
+  🇺🇦 <ion-text color="primary">DVB</ion-text>etter
 </ion-title>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,6 +6,10 @@
         <ion-icon name="train-outline"></ion-icon>
         <ion-label>Departures</ion-label>
       </ion-tab-button>
+      <ion-tab-button tab="settings">
+        <ion-icon name="settings-outline"></ion-icon>
+        <ion-label>Settings</ion-label>
+      </ion-tab-button>
     </ion-tab-bar>
   </ion-tabs>
 </ion-app>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,11 +2,13 @@
   <ion-router-outlet></ion-router-outlet>
   <ion-tabs>
     <ion-tab-bar slot="bottom">
-      <ion-tab-button tab="departures">
+      <ion-tab-button tab="departures" 
+        (click)="titleService.setTitle('Departures – DVBetter')">
         <ion-icon name="train-outline"></ion-icon>
         <ion-label>Departures</ion-label>
       </ion-tab-button>
-      <ion-tab-button tab="settings">
+      <ion-tab-button tab="settings" 
+        (click)="titleService.setTitle('Settings – DVBetter')">
         <ion-icon name="settings-outline"></ion-icon>
         <ion-label>Settings</ion-label>
       </ion-tab-button>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,14 +3,14 @@
   <ion-tabs>
     <ion-tab-bar slot="bottom">
       <ion-tab-button tab="departures" 
-        (click)="titleService.setTitle('Departures – DVBetter')">
+        (click)="titleService.setTitle(translateService.instant('departures.title') + ' – DVBetter')">
         <ion-icon name="train-outline"></ion-icon>
-        <ion-label>Departures</ion-label>
+        <ion-label>{{ 'departures.title' | translate }}</ion-label>
       </ion-tab-button>
       <ion-tab-button tab="settings" 
-        (click)="titleService.setTitle('Settings – DVBetter')">
+        (click)="titleService.setTitle(translateService.instant('settings.title') + ' – DVBetter')">
         <ion-icon name="settings-outline"></ion-icon>
-        <ion-label>Settings</ion-label>
+        <ion-label>{{ 'settings.title' | translate }}</ion-label>
       </ion-tab-button>
     </ion-tab-bar>
   </ion-tabs>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
+import { SettingsStorageService } from './shared/services/settings-storage.service';
 
 @Component({
   selector: 'app-root',
@@ -8,5 +9,16 @@ import { TranslateService } from '@ngx-translate/core';
   styleUrls: ['app.component.scss'],
 })
 export class AppComponent {
-  constructor(private titleService: Title, private translateService: TranslateService) {}
+  constructor(
+    private titleService: Title,
+    private translateService: TranslateService,
+    private settingsStorageService: SettingsStorageService) {
+    let language = this.settingsStorageService.getLanguage();
+
+    if(language === 'system') {
+      language = this.translateService.getBrowserLang();
+    }
+
+    translateService.use(language);
+  }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Title } from '@angular/platform-browser';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
@@ -7,5 +8,5 @@ import { Title } from '@angular/platform-browser';
   styleUrls: ['app.component.scss'],
 })
 export class AppComponent {
-  constructor(private titleService: Title) {}
+  constructor(private titleService: Title, private translateService: TranslateService) {}
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
@@ -6,5 +7,5 @@ import { Component } from '@angular/core';
   styleUrls: ['app.component.scss'],
 })
 export class AppComponent {
-  constructor() {}
+  constructor(private titleService: Title) {}
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,9 +10,9 @@ import { SettingsStorageService } from './shared/services/settings-storage.servi
 })
 export class AppComponent {
   constructor(
-    private titleService: Title,
-    private translateService: TranslateService,
-    private settingsStorageService: SettingsStorageService) {
+    public titleService: Title,
+    public translateService: TranslateService,
+    public settingsStorageService: SettingsStorageService) {
     let language = this.settingsStorageService.getLanguage();
 
     if(language === 'system') {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,7 @@ const httpLoaderFactory = (http: HttpClient) => new TranslateHttpLoader(http, '.
         useFactory: httpLoaderFactory,
         deps: [HttpClient]
       },
-      defaultLanguage: 'de'
+      defaultLanguage: 'en'
     })
   ],
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,11 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { environment } from '../environments/environment';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+const httpLoaderFactory = (http: HttpClient) => new TranslateHttpLoader(http, './assets/i18n/', '.json');
 
 @NgModule({
   declarations: [AppComponent],
@@ -21,6 +26,15 @@ import { environment } from '../environments/environment';
       // Register the ServiceWorker as soon as the app is stable
       // or after 30 seconds (whichever comes first).
       registrationStrategy: 'registerWhenStable:30000'
+    }),
+    HttpClientModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: httpLoaderFactory,
+        deps: [HttpClient]
+      },
+      defaultLanguage: 'en'
     })
   ],
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,7 @@ const httpLoaderFactory = (http: HttpClient) => new TranslateHttpLoader(http, '.
         useFactory: httpLoaderFactory,
         deps: [HttpClient]
       },
-      defaultLanguage: 'en'
+      defaultLanguage: 'de'
     })
   ],
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],

--- a/src/app/departure-card/departure-card.component.html
+++ b/src/app/departure-card/departure-card.component.html
@@ -11,14 +11,10 @@
       <ion-icon slot="icon-only" name="settings-outline" color="dark"></ion-icon>
     </ion-button>
   </ion-item>
-  <ion-card-content *ngIf="!inEditMode && monitoredStation.departures?.length > 0 && !isUpdating">
-    <app-departure-list [monitoredStation]="monitoredStation"></app-departure-list>
-  </ion-card-content>
-  <ion-card-content *ngIf="!inEditMode && isUpdating">
-    <app-departure-skeletons [departureCount]="monitoredStation.departureCount"></app-departure-skeletons>
-  </ion-card-content>
-  <ion-card-content *ngIf="!inEditMode && monitoredStation.departures?.length === 0 && !isUpdating">
-    <h2>No departures found</h2>
+  <ion-card-content *ngIf="!inEditMode">
+    <app-departure-list *ngIf="monitoredStation.departures" [monitoredStation]="monitoredStation"></app-departure-list>
+    <app-departure-skeletons *ngIf="!monitoredStation.departures && isUpdating" [departureCount]="monitoredStation.departureCount"></app-departure-skeletons>
+    <h2 *ngIf="!monitoredStation.departures && !isUpdating">No departures found</h2>
   </ion-card-content>
   <ion-card-content *ngIf="inEditMode">
     <app-monitored-station-editor [monitoredStation]="monitoredStation" (submittedEvent)="onMonitoredStationEditorSubmitted()" 

--- a/src/app/departure-card/departure-card.component.html
+++ b/src/app/departure-card/departure-card.component.html
@@ -5,7 +5,7 @@
       <ion-card-subtitle class="ion-text-nowrap">{{ monitoredStation.station.city }}</ion-card-subtitle>
     </ion-label>
     <app-timer *ngIf="!inEditMode" class="timer-item" [ngClass]="{'clickable': lastUpdatedSeconds > 35}" 
-      [color]="lastUpdatedSeconds <= 35 ? 'medium' : ''" (click)="lastUpdatedSeconds > 35 && updateDepartures()"
+      [color]="lastUpdatedSeconds <= 35 ? 'medium' : ''" (click)="lastUpdatedSeconds > 35 && tapToRefresh()"
       [updateCounterTimestamp]="lastUpdatedTimestamp" [isActive]="!inEditMode"></app-timer>
     <ion-button *ngIf="!inEditMode" class="settings-item" slot="end" fill="clear" size="small" (click)="enterEditMode()">
       <ion-icon slot="icon-only" name="settings-outline" color="dark"></ion-icon>

--- a/src/app/departure-card/departure-card.component.html
+++ b/src/app/departure-card/departure-card.component.html
@@ -14,7 +14,7 @@
   <ion-card-content *ngIf="!inEditMode">
     <app-departure-list *ngIf="monitoredStation.departures" [monitoredStation]="monitoredStation"></app-departure-list>
     <app-departure-skeletons *ngIf="!monitoredStation.departures && isUpdating" [departureCount]="monitoredStation.departureCount"></app-departure-skeletons>
-    <h2 *ngIf="!monitoredStation.departures && !isUpdating">No departures found</h2>
+    <h2 *ngIf="!monitoredStation.departures && !isUpdating">{{ 'departures.none-found' | translate}}</h2>
   </ion-card-content>
   <ion-card-content *ngIf="inEditMode">
     <app-monitored-station-editor [monitoredStation]="monitoredStation" (submittedEvent)="onMonitoredStationEditorSubmitted()" 

--- a/src/app/departure-card/departure-card.component.ts
+++ b/src/app/departure-card/departure-card.component.ts
@@ -32,6 +32,7 @@ export class DepartureCardComponent implements OnInit {
   }
 
   async updateDepartures(): Promise<void> {
+    this.isUpdating = true;
     const departures = await this.departureMonitorService.getDepartures(this.monitoredStation);
     if(!departures && this.monitoredStation.departures) {
       this.isUpdating = false;

--- a/src/app/departure-card/departure-card.component.ts
+++ b/src/app/departure-card/departure-card.component.ts
@@ -32,9 +32,25 @@ export class DepartureCardComponent implements OnInit {
   }
 
   async updateDepartures(): Promise<void> {
-    this.monitoredStation.departures = await this.departureMonitorService.getDepartures(this.monitoredStation);
+    const departures = await this.departureMonitorService.getDepartures(this.monitoredStation);
+    if(!departures && this.monitoredStation.departures) {
+      this.isUpdating = false;
+      return;
+    }
+
+    this.monitoredStation.departures = departures;
     this.isUpdating = false;
     this.lastUpdatedTimestamp = new Date();
+  }
+
+  async tapToRefresh(): Promise<void> {
+    clearInterval(this.updateInterval);
+
+    await this.updateDepartures();
+
+    this.updateInterval = setInterval(() => {
+      this.updateDepartures();
+    }, 30000);
   }
 
   enterEditMode(): void {

--- a/src/app/departure-item/departure-item.component.html
+++ b/src/app/departure-item/departure-item.component.html
@@ -5,7 +5,7 @@
   </ion-avatar>
   <ion-label [ngClass]="{'color-departed': departure.arrivalTimeRelative < 0, 'strikethrough': departure.state === 'Cancelled'}">
     <h2>{{departure.line}} {{departure.direction}}</h2>
-    <h3>{{departure.platform?.type}} {{departure.platform?.name}}</h3>
+    <h3>{{ 'shared.station-types.' + departure.platform?.type | lowercase | translate }} {{departure.platform?.name}}</h3>
   </ion-label>
   <ion-note slot="end" class="ion-text-end" [ngClass]="{'color-departed': departure.arrivalTimeRelative < 0}">
     <h3>{{departureTime}}</h3>

--- a/src/app/departure-item/departure-item.component.scss
+++ b/src/app/departure-item/departure-item.component.scss
@@ -8,6 +8,7 @@ ion-note {
     color: var(--ion-text-color);
     padding: 12px 0 10px 0;
     margin-right: -5px;
+    margin-left: 8px;
 }
 
 .color-on-time {

--- a/src/app/departure-item/departure-item.component.ts
+++ b/src/app/departure-item/departure-item.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import * as dvb from 'dvbjs';
 
 @Component({
@@ -9,17 +10,17 @@ import * as dvb from 'dvbjs';
 export class DepartureItemComponent implements OnInit {
   @Input() departure: dvb.IMonitor;
 
-  constructor() { }
+  constructor(private translateService: TranslateService) { }
 
   ngOnInit() {}
 
   get departureTime(): string {
     if(this.departure.arrivalTimeRelative === 0) {
-      return 'now';
+      return this.translateService.instant('departures.arrival-times.now');
     }
 
     if(this.departure.arrivalTimeRelative < 0) {
-      return Math.abs(this.departure.arrivalTimeRelative) + ' min ago';
+      return this.translateService.instant('departures.arrival-times.min-ago', {count: Math.abs(this.departure.arrivalTimeRelative)});
     }
 
     if(this.departure.arrivalTimeRelative > 30) {
@@ -33,22 +34,22 @@ export class DepartureItemComponent implements OnInit {
       return this.departure.arrivalTime.getHours() + delimiter + minutes;
     }
 
-    return this.departure.arrivalTimeRelative + ' min';
+    return this.translateService.instant('departures.arrival-times.min', {count: this.departure.arrivalTimeRelative});
   }
 
   get delay(): string {
     if(this.departure.state === 'Cancelled') {
-      return 'cancelled';
+      return this.translateService.instant('departures.delays.cancelled');
     }
 
     if(this.departure.delayTime === 0) {
-      return 'on time';
+      return this.translateService.instant('departures.delays.on-time');
     }
 
     if(this.departure.delayTime < 0) {
-      return Math.abs(this.departure.delayTime) + ' min early';
+      return this.translateService.instant('departures.delays.early', {count: Math.abs(this.departure.delayTime)});
     }
 
-    return this.departure.delayTime + ' min late';
+    return this.translateService.instant('departures.delays.late', {count: this.departure.delayTime});
   }
 }

--- a/src/app/departures/departures.module.ts
+++ b/src/app/departures/departures.module.ts
@@ -14,6 +14,7 @@ import { QuickDepartureSearchCardComponent } from '../quick-departure-search-car
 import { DepartureListComponent } from '../departure-list/departure-list.component';
 import { TimerComponent } from '../timer/timer.component';
 import { DepartureSkeletonsComponent } from '../departure-skeletons/departure-skeletons.component';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   imports: [
@@ -21,7 +22,8 @@ import { DepartureSkeletonsComponent } from '../departure-skeletons/departure-sk
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    DeparturesPageRoutingModule
+    DeparturesPageRoutingModule,
+    TranslateModule
   ],
   declarations: [
     AppTitleComponent,

--- a/src/app/departures/departures.module.ts
+++ b/src/app/departures/departures.module.ts
@@ -2,9 +2,12 @@ import { IonicModule } from '@ionic/angular';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { DeparturesPage } from './departures.page';
 
 import { DeparturesPageRoutingModule } from './departures-routing.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { SharedComponentsModule } from '../shared-components/shared-components.module';
+
+import { DeparturesPage } from './departures.page';
 import { DepartureCardComponent } from '../departure-card/departure-card.component';
 import { DepartureItemComponent } from '../departure-item/departure-item.component';
 import { MonitoredStationEditorComponent } from '../monitored-station-editor/monitored-station-editor.component';
@@ -13,8 +16,6 @@ import { QuickDepartureSearchCardComponent } from '../quick-departure-search-car
 import { DepartureListComponent } from '../departure-list/departure-list.component';
 import { TimerComponent } from '../timer/timer.component';
 import { DepartureSkeletonsComponent } from '../departure-skeletons/departure-skeletons.component';
-import { TranslateModule } from '@ngx-translate/core';
-import { SharedComponentsModule } from '../shared-components/shared-components.module';
 
 @NgModule({
   imports: [

--- a/src/app/departures/departures.module.ts
+++ b/src/app/departures/departures.module.ts
@@ -4,7 +4,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DeparturesPage } from './departures.page';
 
-import { AppTitleComponent } from '../app-title/app-title.component';
 import { DeparturesPageRoutingModule } from './departures-routing.module';
 import { DepartureCardComponent } from '../departure-card/departure-card.component';
 import { DepartureItemComponent } from '../departure-item/departure-item.component';
@@ -15,6 +14,7 @@ import { DepartureListComponent } from '../departure-list/departure-list.compone
 import { TimerComponent } from '../timer/timer.component';
 import { DepartureSkeletonsComponent } from '../departure-skeletons/departure-skeletons.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { SharedComponentsModule } from '../shared-components/shared-components.module';
 
 @NgModule({
   imports: [
@@ -23,10 +23,10 @@ import { TranslateModule } from '@ngx-translate/core';
     FormsModule,
     ReactiveFormsModule,
     DeparturesPageRoutingModule,
-    TranslateModule
+    TranslateModule,
+    SharedComponentsModule
   ],
   declarations: [
-    AppTitleComponent,
     DeparturesPage,
     DepartureCardComponent,
     QuickDepartureSearchCardComponent,

--- a/src/app/departures/departures.page.html
+++ b/src/app/departures/departures.page.html
@@ -1,9 +1,9 @@
-<title>Departures – DVBetter</title>
+<title>{{ 'departures.title' | translate }} – DVBetter</title>
 
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-title class="ion-float-start">
-      Departures
+      {{ 'departures.title' | translate }}
     </ion-title>
     <app-title class="ion-float-end"></app-title>
   </ion-toolbar>

--- a/src/app/departures/departures.page.ts
+++ b/src/app/departures/departures.page.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { Component, OnInit } from '@angular/core';
 import { ToastController } from '@ionic/angular';
+import { TranslateService } from '@ngx-translate/core';
 
 import { MonitoredStation } from '../shared/models/monitored-station.model';
 import { DepartureMonitorService } from '../shared/services/departure-monitor.service';
@@ -13,7 +14,11 @@ import { DepartureMonitorService } from '../shared/services/departure-monitor.se
 export class DeparturesPage implements OnInit {
   monitoredStations: MonitoredStation[] = [];
 
-  constructor(private departureMonitorService: DepartureMonitorService, private toastController: ToastController) { }
+  constructor(
+    private departureMonitorService: DepartureMonitorService,
+    private toastController: ToastController,
+    private translateService: TranslateService)
+  { }
 
   async ngOnInit() {
     this.monitoredStations = await this.departureMonitorService.getMonitoredStations();
@@ -28,7 +33,7 @@ export class DeparturesPage implements OnInit {
     this.monitoredStations.push(stationToAdd);
 
     const toast = await this.toastController.create({
-      message: this.getCombinedStationName(stationToAdd) + ' added to favorites',
+      message: this.translateService.instant('shared.favorite.added', {name: this.getCombinedStationName(stationToAdd)}),
       duration: 3000
     });
     toast.present();
@@ -41,7 +46,7 @@ export class DeparturesPage implements OnInit {
     const removedStations = this.monitoredStations.splice(index, 1);
 
     const toast = await this.toastController.create({
-      message: this.getCombinedStationName(removedStations[0]) + ' removed from favorites',
+      message: this.translateService.instant('shared.favorite.removed', {name: this.getCombinedStationName(removedStations[0])}),
       duration: 3000
     });
     toast.present();

--- a/src/app/language-picker/language-picker.component.html
+++ b/src/app/language-picker/language-picker.component.html
@@ -1,0 +1,9 @@
+<ion-item>
+  <ion-label>{{ 'settings.language.title' | translate }}</ion-label>
+  <ion-select cancelText="{{ 'shared.inputs.cancel' | translate }}" okText="{{ 'shared.inputs.done' | translate }}"
+    [value]="currentLanguage" (ionChange)="selectLanguage($event)">
+    <ion-select-option value="system">{{ 'settings.language.options.system' | translate }}</ion-select-option>
+    <ion-select-option value="de">{{ 'settings.language.options.german' | translate }}</ion-select-option>
+    <ion-select-option value="en">{{ 'settings.language.options.english' | translate }}</ion-select-option>
+    </ion-select>
+</ion-item>

--- a/src/app/language-picker/language-picker.component.spec.ts
+++ b/src/app/language-picker/language-picker.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { LanguagePickerComponent } from './language-picker.component';
+
+describe('LanguagePickerComponent', () => {
+  let component: LanguagePickerComponent;
+  let fixture: ComponentFixture<LanguagePickerComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LanguagePickerComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LanguagePickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/language-picker/language-picker.component.ts
+++ b/src/app/language-picker/language-picker.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { SettingsStorageService } from '../shared/services/settings-storage.service';
+
+@Component({
+  selector: 'app-language-picker',
+  templateUrl: './language-picker.component.html',
+  styleUrls: ['./language-picker.component.scss'],
+})
+export class LanguagePickerComponent implements OnInit {
+  currentLanguage: string;
+
+  constructor(
+    private translateService: TranslateService,
+    private settingsStorageService: SettingsStorageService) {
+
+    }
+
+  ngOnInit() {
+    this.currentLanguage = this.settingsStorageService.getLanguage();
+  }
+
+  selectLanguage($event: any): void {
+    const language = $event.target.value;
+    this.settingsStorageService.setLanguage(language);
+    this.currentLanguage = language;
+
+    if(language === 'system') {
+      this.translateService.use(this.translateService.getBrowserLang());
+    }
+
+    this.translateService.use(language);
+  }
+}

--- a/src/app/monitored-station-editor/monitored-station-editor.component.html
+++ b/src/app/monitored-station-editor/monitored-station-editor.component.html
@@ -1,14 +1,15 @@
 <ion-item>
-  <ion-label position="floating">Departure count</ion-label>
+  <ion-label position="floating">{{ 'departures.departure-count' | translate }}</ion-label>
   <ion-input type="number" min="1" max="10" [formControl]="departureCount"></ion-input>
 </ion-item>
-<ion-text *ngIf="departureCount.invalid && (departureCount.dirty || departureCount.touched)" color="danger">Please enter a number between 1 and 10.</ion-text>
+<ion-text *ngIf="departureCount.invalid && (departureCount.dirty || departureCount.touched)" color="danger">
+  {{ 'shared.inputs.restraints.range' | translate:{lower: '1', upper: '10'} }}</ion-text>
 <ion-row style="height: 1em"></ion-row>
 <ion-button (click)="submit()" [disabled]="!isFormValid">
   <ion-icon slot="start" name="save-outline"></ion-icon>
-  Save
+  {{ 'shared.inputs.save' | translate }}
 </ion-button>
 <ion-button class="ion-float-right" fill="clear" color="danger" (click)="removeStationFromFavorites()">
   <ion-icon slot="start" name="trash-outline"></ion-icon>
-  Delete
+  {{ 'shared.inputs.delete' | translate }}
 </ion-button>

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.html
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.html
@@ -41,9 +41,9 @@
     <ion-text color="dark">
       Departing at {{ formattedDepartureTime }}
     </ion-text>
-    <app-departure-list *ngIf="selectedStation.departures?.length > 0 && !isUpdating" [monitoredStation]="selectedStation"></app-departure-list>
-    <h2 class="no-departures" *ngIf="selectedStation.departures?.length === 0  && !isUpdating">No departures found</h2>
-    <app-departure-skeletons *ngIf="selectedStation.departures?.length === 0 && isUpdating" 
+    <app-departure-list *ngIf="selectedStation.departures" [monitoredStation]="selectedStation"></app-departure-list>
+    <h2 class="no-departures" *ngIf="!selectedStation.departures  && !isUpdating">No departures found</h2>
+    <app-departure-skeletons *ngIf="!selectedStation.departures && isUpdating" 
       [departureCount]="selectedStation.departureCount"></app-departure-skeletons>
   </ion-card-content>
 </ion-card>

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.html
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.html
@@ -25,7 +25,7 @@
       <ion-card-subtitle class="ion-text-nowrap">{{ selectedStation.station.city }}</ion-card-subtitle>
     </ion-label>
     <app-timer class="timer-item" [ngClass]="{'clickable': lastUpdatedSeconds > 35}" 
-      [color]="lastUpdatedSeconds <= 35 ? 'medium' : ''" (click)="lastUpdatedSeconds > 35 && updateDepartures()"
+      [color]="lastUpdatedSeconds <= 35 ? 'medium' : ''" (click)="lastUpdatedSeconds > 35 && tapToRefresh()"
       [updateCounterTimestamp]="lastUpdatedTimestamp" [isActive]="inStationSelectedMode"></app-timer>
     <ion-button *ngIf="!isStationInFavorites" class="card-button-item" fill="clear" size="small" (click)="addStationToFavorites()">
       <ion-icon slot="icon-only" name="star-outline" color="dark"></ion-icon>

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.html
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.html
@@ -1,20 +1,20 @@
 <ion-card *ngIf="!inStationSelectedMode">
   <ion-item lines="none">
     <ion-label>
-      <ion-card-title class="ion-text-nowrap">Quick search</ion-card-title>
+      <ion-card-title class="ion-text-nowrap">{{ 'departures.quick-search-title' | translate }}</ion-card-title>
     </ion-label>
   </ion-item>
   <ion-card-content>
     <app-station-picker [selectedStation]="selectedStation" (stationNameValidityChangedEvent)="onStationNameValidityChanged($event)" 
       (selectedStationChangedEvent)="onSelectedStationChanged($event)"></app-station-picker>
     <ion-item>
-      <ion-label position="floating">Departure time</ion-label>
+      <ion-label position="floating">{{ 'shared.times.departure-time' | translate }}</ion-label>
       <ion-datetime [formControl]="departureTime" displayFormat="DD.MM.YYYY, HH:mm" min="{{ currentDate }}" max="{{ maxDate }}"></ion-datetime>
     </ion-item>
     <ion-row style="height: 1em"></ion-row>
     <ion-button (click)="searchDepartures()" [disabled]="!isStationNameValid">
       <ion-icon slot="start" name="search-outline"></ion-icon>
-      Search
+      {{ 'shared.inputs.search' | translate }}
     </ion-button>
   </ion-card-content>
 </ion-card>
@@ -39,10 +39,10 @@
   </ion-item>
   <ion-card-content>
     <ion-text color="dark">
-      Departing at {{ formattedDepartureTime }}
+      {{ 'shared.times.departing-at' | translate:{time: formattedDepartureTime} }}
     </ion-text>
     <app-departure-list *ngIf="selectedStation.departures" [monitoredStation]="selectedStation"></app-departure-list>
-    <h2 class="no-departures" *ngIf="!selectedStation.departures  && !isUpdating">No departures found</h2>
+    <h2 class="no-departures" *ngIf="!selectedStation.departures  && !isUpdating">{{ 'departures.none-found' | translate }}</h2>
     <app-departure-skeletons *ngIf="!selectedStation.departures && isUpdating" 
       [departureCount]="selectedStation.departureCount"></app-departure-skeletons>
   </ion-card-content>

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.html
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.html
@@ -9,7 +9,8 @@
       (selectedStationChangedEvent)="onSelectedStationChanged($event)"></app-station-picker>
     <ion-item>
       <ion-label position="floating">{{ 'shared.times.departure-time' | translate }}</ion-label>
-      <ion-datetime [formControl]="departureTime" displayFormat="DD.MM.YYYY, HH:mm" min="{{ currentDate }}" max="{{ maxDate }}"></ion-datetime>
+      <ion-datetime [formControl]="departureTime" displayFormat="DD.MM.YYYY, HH:mm" min="{{ currentDate }}" max="{{ maxDate }}" 
+        cancelText="{{ 'shared.inputs.cancel' | translate }}" doneText="{{ 'shared.inputs.done' | translate }}"></ion-datetime>
     </ion-item>
     <ion-row style="height: 1em"></ion-row>
     <ion-button (click)="searchDepartures()" [disabled]="!isStationNameValid">

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.html
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.html
@@ -40,7 +40,7 @@
   </ion-item>
   <ion-card-content>
     <ion-text color="dark">
-      {{ 'shared.times.departing-at' | translate:{time: formattedDepartureTime} }}
+      {{ 'shared.times.departing-at' | translate: {time: formattedDepartureTime} }}
     </ion-text>
     <app-departure-list *ngIf="selectedStation.departures" [monitoredStation]="selectedStation"></app-departure-list>
     <h2 class="no-departures" *ngIf="!selectedStation.departures  && !isUpdating">{{ 'departures.none-found' | translate }}</h2>

--- a/src/app/quick-departure-search-card/quick-departure-search-card.component.ts
+++ b/src/app/quick-departure-search-card/quick-departure-search-card.component.ts
@@ -58,6 +58,8 @@ export class QuickDepartureSearchCardComponent implements OnInit {
   }
 
   async updateDepartures(): Promise<void> {
+    this.isUpdating = true;
+
     let minutesFromNow = differenceInMinutes(new Date(this.departureTime.value), new Date());
     if(minutesFromNow < 0) {
       minutesFromNow = 0;

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { SettingsPage } from './settings.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SettingsPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SettingsPageRoutingModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -9,6 +9,7 @@ import { SettingsPageRoutingModule } from './settings-routing.module';
 
 import { SettingsPage } from './settings.page';
 import { AppTitleComponent } from '../app-title/app-title.component';
+import { LanguagePickerComponent } from '../language-picker/language-picker.component';
 
 @NgModule({
   imports: [
@@ -20,7 +21,8 @@ import { AppTitleComponent } from '../app-title/app-title.component';
   ],
   declarations: [
     SettingsPage,
-    AppTitleComponent
+    AppTitleComponent,
+    LanguagePickerComponent
   ]
 })
 export class SettingsPageModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -8,9 +8,9 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SettingsPageRoutingModule } from './settings-routing.module';
 
 import { SettingsPage } from './settings.page';
-import { AppTitleComponent } from '../app-title/app-title.component';
 import { LanguagePickerComponent } from '../language-picker/language-picker.component';
 import { AboutComponent } from '../about/about.component';
+import { SharedComponentsModule } from '../shared-components/shared-components.module';
 
 @NgModule({
   imports: [
@@ -18,11 +18,11 @@ import { AboutComponent } from '../about/about.component';
     FormsModule,
     IonicModule,
     SettingsPageRoutingModule,
-    TranslateModule
+    TranslateModule,
+    SharedComponentsModule
   ],
   declarations: [
     SettingsPage,
-    AppTitleComponent,
     LanguagePickerComponent,
     AboutComponent
   ]

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { SettingsPageRoutingModule } from './settings-routing.module';
 
@@ -14,7 +15,8 @@ import { AppTitleComponent } from '../app-title/app-title.component';
     CommonModule,
     FormsModule,
     IonicModule,
-    SettingsPageRoutingModule
+    SettingsPageRoutingModule,
+    TranslateModule
   ],
   declarations: [
     SettingsPage,

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { SettingsPageRoutingModule } from './settings-routing.module';
+
+import { SettingsPage } from './settings.page';
+import { AppTitleComponent } from '../app-title/app-title.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    SettingsPageRoutingModule
+  ],
+  declarations: [
+    SettingsPage,
+    AppTitleComponent
+  ]
+})
+export class SettingsPageModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -6,11 +6,11 @@ import { IonicModule } from '@ionic/angular';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { SettingsPageRoutingModule } from './settings-routing.module';
+import { SharedComponentsModule } from '../shared-components/shared-components.module';
 
 import { SettingsPage } from './settings.page';
 import { LanguagePickerComponent } from '../language-picker/language-picker.component';
 import { AboutComponent } from '../about/about.component';
-import { SharedComponentsModule } from '../shared-components/shared-components.module';
 
 @NgModule({
   imports: [

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -10,6 +10,7 @@ import { SettingsPageRoutingModule } from './settings-routing.module';
 import { SettingsPage } from './settings.page';
 import { AppTitleComponent } from '../app-title/app-title.component';
 import { LanguagePickerComponent } from '../language-picker/language-picker.component';
+import { AboutComponent } from '../about/about.component';
 
 @NgModule({
   imports: [
@@ -22,7 +23,8 @@ import { LanguagePickerComponent } from '../language-picker/language-picker.comp
   declarations: [
     SettingsPage,
     AppTitleComponent,
-    LanguagePickerComponent
+    LanguagePickerComponent,
+    AboutComponent
   ]
 })
 export class SettingsPageModule {}

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -8,6 +8,9 @@
 </ion-header>
 
 <ion-content [fullscreen]="true">
+  <div class="divider"></div>
   <app-language-picker></app-language-picker>
-  <app-about></app-about>
+  <div class="container">
+    <app-about></app-about>
+  </div>
 </ion-content>

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -8,5 +8,5 @@
 </ion-header>
 
 <ion-content [fullscreen]="true">
-
+  <app-language-picker></app-language-picker>
 </ion-content>

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -1,8 +1,8 @@
-<title>Settings – DVBetter</title>
+<title>{{ 'settings.title' | translate }} – DVBetter</title>
 
 <ion-header [translucent]="true">
   <ion-toolbar>
-    <ion-title class="ion-float-start">Settings</ion-title>
+    <ion-title class="ion-float-start">{{ 'settings.title' | translate }}</ion-title>
     <app-title class="ion-float-end"></app-title>
   </ion-toolbar>
 </ion-header>

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -9,4 +9,5 @@
 
 <ion-content [fullscreen]="true">
   <app-language-picker></app-language-picker>
+  <app-about></app-about>
 </ion-content>

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -1,0 +1,12 @@
+<title>Settings – DVBetter</title>
+
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title class="ion-float-start">Settings</ion-title>
+    <app-title class="ion-float-end"></app-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+
+</ion-content>

--- a/src/app/settings/settings.page.scss
+++ b/src/app/settings/settings.page.scss
@@ -1,0 +1,7 @@
+.container {
+    padding: 16px;
+}
+
+.divider {
+    padding: 8px 0 8px 0;
+}

--- a/src/app/settings/settings.page.spec.ts
+++ b/src/app/settings/settings.page.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { SettingsPage } from './settings.page';
+
+describe('SettingsPage', () => {
+  let component: SettingsPage;
+  let fixture: ComponentFixture<SettingsPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SettingsPage ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.page.html',
+  styleUrls: ['./settings.page.scss'],
+})
+export class SettingsPage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/shared-components/shared-components.module.ts
+++ b/src/app/shared-components/shared-components.module.ts
@@ -1,9 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { AppTitleComponent } from '../app-title/app-title.component';
 import { IonicModule } from '@ionic/angular';
 
-
+import { AppTitleComponent } from '../app-title/app-title.component';
 
 @NgModule({
   declarations: [

--- a/src/app/shared-components/shared-components.module.ts
+++ b/src/app/shared-components/shared-components.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AppTitleComponent } from '../app-title/app-title.component';
+import { IonicModule } from '@ionic/angular';
+
+
+
+@NgModule({
+  declarations: [
+    AppTitleComponent
+  ],
+  imports: [
+    CommonModule,
+    IonicModule
+  ],
+  exports: [
+    AppTitleComponent
+  ]
+})
+export class SharedComponentsModule { }

--- a/src/app/shared/services/settings-storage.service.ts
+++ b/src/app/shared/services/settings-storage.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SettingsStorageService {
+  constructor() { }
+
+  getLanguage(): string {
+    if(localStorage) {
+      return localStorage.language || 'system';
+    }
+    else {
+      return '';
+    }
+  }
+
+  setLanguage(language: string): void {
+    if(localStorage) {
+      localStorage.language = language;
+    }
+  }
+}

--- a/src/app/station-picker/station-picker.component.html
+++ b/src/app/station-picker/station-picker.component.html
@@ -1,8 +1,9 @@
 <ion-item>
-  <ion-label position="floating">Station</ion-label>
+  <ion-label position="floating">{{ 'shared.inputs.station' | translate }}</ion-label>
   <ion-input type="text" debounce="250" (ionInput)="getMatchingStations($event)" [formControl]="stationName"></ion-input>
 </ion-item>
-<ion-text *ngIf="!stationNameValid && (stationName.dirty || stationName.touched)" color="danger">Please choose a station.</ion-text>
+<ion-text *ngIf="!stationNameValid && (stationName.dirty || stationName.touched)" color="danger">
+  {{ 'shared.inputs.restraints.station' | translate }}</ion-text>
 <ion-list>
   <ion-item *ngFor="let matchingStation of matchingStations" button (click)="selectStation(matchingStation)">
     <ion-label>

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -52,6 +52,7 @@
                 "german": "Deutsch",
                 "english": "English"
             }
-        }
+        },
+        "no-affiliation": "Diese App steht in keinerlei Verbindung zur Dresdner Verkehrsbetriebe AG."
     }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -44,6 +44,14 @@
         }
     },
     "settings": {
-        "title": "Einstellungen"
+        "title": "Einstellungen",
+        "language": {
+            "title": "Sprache",
+            "options": {
+                "system": "Systemsprache",
+                "german": "Deutsch",
+                "english": "English"
+            }
+        }
     }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1,0 +1,49 @@
+{
+    "shared": {
+        "station-types": {
+            "platform": "Steig",
+            "railtrack": "Gleis",
+            "null": ""
+        },
+        "favorite": {
+            "added": "{{name}} zu Favoriten hinzugefügt",
+            "removed": "{{name}} aus Favoriten entfernt"
+        },
+        "inputs": {
+            "save": "Speichern",
+            "delete": "Löschen",
+            "cancel": "Abbrechen",
+            "done": "Fertig",
+            "search": "Suchen",
+            "station": "Haltestelle",
+            "restraints" : {
+                "range": "Bitte geben Sie eine Zahl zwischen {{lower}} und {{upper}} ein.",
+                "station": "Bitte wählen Sie eine Haltestelle aus."
+            }
+        },
+        "times": {
+            "departure-time": "Abfahrtszeit",
+            "departing-at": "Abfahrt am {{time}}"
+        }
+    },
+    "departures": {
+        "title": "Abfahrten",
+        "none-found": "Keine Abfahrten gefunden",
+        "departure-count": "Anzahl Abfahrten",
+        "quick-search-title": "Suche",
+        "arrival-times": {
+            "now": "jetzt",
+            "min": "{{count}} min",
+            "min-ago": "vor {{count}} min"
+        },
+        "delays": {
+            "on-time": "pünktlich",
+            "late": "{{count}} min zu spät",
+            "early": "{{count}} min zu früh",
+            "cancelled": "fällt aus"
+        }
+    },
+    "settings": {
+        "title": "Einstellungen"
+    }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -44,6 +44,14 @@
         }
     },
     "settings": {
-        "title": "Settings"
+        "title": "Settings",
+        "language": {
+            "title": "Language",
+            "options": {
+                "system": "System language",
+                "german": "Deutsch",
+                "english": "English"
+            }
+        }
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -52,6 +52,7 @@
                 "german": "Deutsch",
                 "english": "English"
             }
-        }
+        },
+        "no-affiliation": "This app is in no way affiliated with Dresdner Verkehrsbetriebe AG."
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,0 +1,23 @@
+{
+    "shared": {
+        "station-types": {
+            "platform": "Stand",
+            "railtrack": "Track"
+        }
+    },
+    "departures": {
+        "title": "Departures",
+        "none-found": "No departures found",
+        "arrival-times": {
+            "now": "now",
+            "min": "{{count}} min",
+            "min-ago": "{{count}} min ago"
+        },
+        "delays": {
+            "on-time": "on time",
+            "late": "{{count}} min late",
+            "early": "{{count}} min early",
+            "cancelled": "cancelled"
+        }
+    }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2,12 +2,33 @@
     "shared": {
         "station-types": {
             "platform": "Stand",
-            "railtrack": "Track"
+            "railtrack": "Track",
+            "null": ""
+        },
+        "favorite": {
+            "added": "{{name}} added to favorites",
+            "removed": "{{name}} removed from favorites"
+        },
+        "inputs": {
+            "save": "Save",
+            "delete": "Delete",
+            "search": "Search",
+            "station": "Station",
+            "restraints" : {
+                "range": "Please enter a number between {{lower}} and {{upper}}.",
+                "station": "Please choose a station."
+            }
+        },
+        "times": {
+            "departure-time": "Departure time",
+            "departing-at": "Departing at {{time}}"
         }
     },
     "departures": {
         "title": "Departures",
         "none-found": "No departures found",
+        "departure-count": "Departure count",
+        "quick-search-title": "Search",
         "arrival-times": {
             "now": "now",
             "min": "{{count}} min",
@@ -19,5 +40,8 @@
             "early": "{{count}} min early",
             "cancelled": "cancelled"
         }
+    },
+    "settings": {
+        "title": "Settings"
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -12,6 +12,8 @@
         "inputs": {
             "save": "Save",
             "delete": "Delete",
+            "cancel": "Cancel",
+            "done": "Done",
             "search": "Search",
             "station": "Station",
             "restraints" : {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ngx-translate/core@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@ngx-translate/core@npm:14.0.0"
+  dependencies:
+    tslib: ^2.3.0
+  peerDependencies:
+    "@angular/core": ">=13.0.0"
+    rxjs: ^6.5.3 || ^7.4.0
+  checksum: d1afc35e7b729caf776e78c10badc0853b63252bdf2fa129f1b95a271cd15cf6f22ffecc52922ffbe1c3aca7d8e08351669e8bae18727664aba66b5d405f05e1
+  languageName: node
+  linkType: hard
+
+"@ngx-translate/http-loader@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@ngx-translate/http-loader@npm:7.0.0"
+  dependencies:
+    tslib: ^2.3.0
+  peerDependencies:
+    "@angular/common": ">=13.0.0"
+    "@ngx-translate/core": ">=14.0.0"
+    rxjs: ^6.5.3 || ^7.4.0
+  checksum: ac20c888c7955656b729029a521d85b0f9964ab2acfd4c42faa37fde3aa56ea56a9ea0424ddf102cac2f33cec2d411b6359f062c068ec3c3e1163b7a465c1c4b
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -5253,6 +5278,8 @@ __metadata:
     "@capacitor/status-bar": 1.0.2
     "@ionic/angular": ^5.5.2
     "@ionic/angular-toolkit": ^4.0.0
+    "@ngx-translate/core": ^14.0.0
+    "@ngx-translate/http-loader": ^7.0.0
     "@types/jasmine": ~3.6.0
     "@types/jasminewd2": ~2.0.3
     "@types/node": ^12.11.1
@@ -12783,7 +12810,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9


### PR DESCRIPTION
- Adds a settings tab that allows switching between different languages.
- Adds a German translation and improves the English translaton.
- By default, the system language is used. If it is not German or English, the latter is used by default.
- Reduced the space between the departure destination and departure time, giving more space for longer destinations.
- Fixed tap to refresh not working as intended.
- Fixed some display issues in the departure list.

resolves #3 