### PR TITLE
fix: Various issues caused by previous version

### DIFF
--- a/src/app/departures/card/favorite/departures-card-favorite.component.html
+++ b/src/app/departures/card/favorite/departures-card-favorite.component.html
@@ -7,11 +7,9 @@
     <app-timer *ngIf="!inEditMode" 
       class="timer-item"
       [start]="lastUpdate"
-      [interval]="30" 
       [update]="!inEditMode"
       [clickable]="secondsElapsed > 35"
-      (click)="secondsElapsed > 35 && updateDepartures()"
-      (elapsed)="updateDepartures()"></app-timer>
+      (click)="secondsElapsed > 35 && updateDepartures()"></app-timer>
     <ion-button *ngIf="!inEditMode" class="settings-item" slot="end" fill="clear" size="small" (click)="enterEditMode()">
       <ion-icon slot="icon-only" name="settings-outline" color="dark"></ion-icon>
     </ion-button>

--- a/src/app/departures/card/favorite/departures-card-favorite.component.ts
+++ b/src/app/departures/card/favorite/departures-card-favorite.component.ts
@@ -19,6 +19,8 @@ export class DeparturesCardFavoriteComponent implements OnInit {
   isUpdating = true;
   lastUpdate: Date;
 
+  updateInterval: NodeJS.Timeout;
+
   constructor(
     private helperService: HelperService,
     private apiService: ApiService,
@@ -28,12 +30,18 @@ export class DeparturesCardFavoriteComponent implements OnInit {
   async ngOnInit() {
     this.stationService.getStationUpdated().subscribe(s => this.onStationUpdated(s));
 
-    this.lastUpdate = new Date();
     await this.updateDepartures();
+    this.setUpdateInterval();
   }
 
   get secondsElapsed(): number {
     return this.lastUpdate ? this.helperService.getSecondsElapsed(this.lastUpdate) : 0;
+  }
+
+  setUpdateInterval(): void {
+    this.updateInterval = setInterval(() => {
+      this.updateDepartures();
+    }, 30000);
   }
 
   async updateDepartures(): Promise<void> {
@@ -51,6 +59,7 @@ export class DeparturesCardFavoriteComponent implements OnInit {
   }
 
   enterEditMode(): void {
+    clearInterval(this.updateInterval);
     this.inEditMode = true;
   }
 
@@ -62,7 +71,9 @@ export class DeparturesCardFavoriteComponent implements OnInit {
 
   async onEditorSubmitted(): Promise<void> {
     this.departures = [];
+    this.lastUpdate = null;
     this.inEditMode = false;
     await this.updateDepartures();
+    this.setUpdateInterval();
   }
 }

--- a/src/app/departures/card/favorite/departures-card-favorite.component.ts
+++ b/src/app/departures/card/favorite/departures-card-favorite.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { Component, Input, OnInit } from '@angular/core';
-import { HelperService } from 'src/app/shared/services/helper.service';
+import { DateTimeService } from 'src/app/shared/services/date-time.service';
 import { ApiService } from 'src/app/shared/services/api.service';
 import { StationService } from 'src/app/shared/services/station.service';
 import { Station } from '../../../shared/models/station.model';
@@ -22,7 +22,7 @@ export class DeparturesCardFavoriteComponent implements OnInit {
   updateInterval: NodeJS.Timeout;
 
   constructor(
-    private helperService: HelperService,
+    private dateTimeService: DateTimeService,
     private apiService: ApiService,
     private stationService: StationService)
   { }
@@ -35,7 +35,7 @@ export class DeparturesCardFavoriteComponent implements OnInit {
   }
 
   get secondsElapsed(): number {
-    return this.lastUpdate ? this.helperService.getSecondsElapsed(this.lastUpdate) : 0;
+    return this.lastUpdate ? this.dateTimeService.getSecondsElapsed(this.lastUpdate) : 0;
   }
 
   setUpdateInterval(): void {

--- a/src/app/departures/card/quick-search/departures-card-quick-search.component.html
+++ b/src/app/departures/card/quick-search/departures-card-quick-search.component.html
@@ -12,7 +12,7 @@
         cancelText="{{ 'shared.inputs.cancel' | translate }}" doneText="{{ 'shared.inputs.done' | translate }}"></ion-datetime>
     </ion-item>
     <ion-row style="height: 1em"></ion-row>
-    <ion-button (click)="searchDepartures()" [disabled]="!selectedStation">
+    <ion-button (click)="enterStationSelectedMode()" [disabled]="!selectedStation">
       <ion-icon slot="start" name="search-outline"></ion-icon>
       {{ 'shared.inputs.search' | translate }}
     </ion-button>
@@ -26,11 +26,9 @@
     </ion-label>
     <app-timer class="timer-item"
       [start]="lastUpdate"
-      [interval]="30"
       [update]="inStationSelectedMode"
       [clickable]="secondsElapsed > 35"
-      (click)="secondsElapsed > 35 && updateDepartures()"
-      (elapsed)="updateDepartures()"></app-timer>
+      (click)="secondsElapsed > 35 && updateDepartures()"></app-timer>
     <ion-button *ngIf="!isStationInFavorites" class="card-button-item" fill="clear" size="small" (click)="addStationToFavorites()">
       <ion-icon slot="icon-only" name="star-outline" color="dark"></ion-icon>
     </ion-button>

--- a/src/app/departures/card/quick-search/departures-card-quick-search.component.ts
+++ b/src/app/departures/card/quick-search/departures-card-quick-search.component.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { format, add, differenceInMinutes } from 'date-fns';
+import { format, add } from 'date-fns';
 import { DateTimeService } from 'src/app/shared/services/date-time.service';
 import { ApiService } from 'src/app/shared/services/api.service';
 import { StationService } from 'src/app/shared/services/station.service';
@@ -56,7 +56,7 @@ export class DeparturesCardQuickSearchComponent implements OnInit {
     this.currentDate = format(currentDateObj, 'yyyy-MM-dd\'T\'HH:mm');
     this.maxDate = format(add(currentDateObj, { months: 1 }), 'yyyy-MM-dd\'T\'HH:mm');
 
-    if(this.departureTime && differenceInMinutes(new Date(this.departureTime.value), new Date()) < 0) {
+    if(this.departureTime && this.dateTimeService.getMinutesFromNow(new Date(this.departureTime.value)) < 0) {
       this.departureTime.setValue(this.currentDate);
     }
   }
@@ -64,7 +64,7 @@ export class DeparturesCardQuickSearchComponent implements OnInit {
   async updateDepartures(): Promise<void> {
     this.isUpdating = true;
 
-    let minutesFromNow = differenceInMinutes(new Date(this.departureTime.value), new Date());
+    let minutesFromNow = this.dateTimeService.getMinutesFromNow(new Date(this.departureTime.value));
     if(minutesFromNow < 0) {
       minutesFromNow = 0;
     }

--- a/src/app/departures/card/quick-search/departures-card-quick-search.component.ts
+++ b/src/app/departures/card/quick-search/departures-card-quick-search.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { format, add, differenceInMinutes } from 'date-fns';
-import { HelperService } from 'src/app/shared/services/helper.service';
+import { DateTimeService } from 'src/app/shared/services/date-time.service';
 import { ApiService } from 'src/app/shared/services/api.service';
 import { StationService } from 'src/app/shared/services/station.service';
 import { Station } from 'src/app/shared/models/station.model';
@@ -29,7 +29,7 @@ export class DeparturesCardQuickSearchComponent implements OnInit {
   updateDeparturesInterval: NodeJS.Timeout;
 
   constructor(
-    private helperService: HelperService,
+    private dateTimeService: DateTimeService,
     private apiService: ApiService,
     private stationService: StationService)
   { }
@@ -48,7 +48,7 @@ export class DeparturesCardQuickSearchComponent implements OnInit {
   }
 
   get secondsElapsed(): number {
-    return this.lastUpdate ? this.helperService.getSecondsElapsed(this.lastUpdate) : 0;
+    return this.lastUpdate ? this.dateTimeService.getSecondsElapsed(this.lastUpdate) : 0;
   }
 
   updateCurrentDate(): void {

--- a/src/app/settings/about/settings-about.component.html
+++ b/src/app/settings/about/settings-about.component.html
@@ -2,4 +2,6 @@
   <a href="https://github.com/benjamin-hempel/dvbetter" target="_blank"><ion-icon name="logo-github" size="large">GitHub</ion-icon></a>
   <br />
   <ion-text color="medium">{{ 'settings.no-affiliation' | translate }}</ion-text>
+  <br />
+  <ion-text color="medium">22.7.31.1</ion-text>
 </div>

--- a/src/app/shared/components/timer/timer.component.ts
+++ b/src/app/shared/components/timer/timer.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { HelperService } from '../../services/helper.service';
+import { DateTimeService } from '../../services/date-time.service';
 
 @Component({
   selector: 'app-timer',
@@ -15,7 +15,7 @@ export class TimerComponent implements OnInit {
 
   updateInterval: NodeJS.Timeout;
 
-  constructor(private helperService: HelperService) { }
+  constructor(private dateTimeService: DateTimeService) { }
 
   ngOnInit() {
     this.updateInterval = setInterval(() => {
@@ -25,7 +25,7 @@ export class TimerComponent implements OnInit {
 
   compute(): void {
     if(this.update) {
-      this.value = this.start ? this.helperService.getSecondsElapsed(this.start) : 0;
+      this.value = this.start ? this.dateTimeService.getSecondsElapsed(this.start) : 0;
     }
   }
 }

--- a/src/app/shared/components/timer/timer.component.ts
+++ b/src/app/shared/components/timer/timer.component.ts
@@ -8,10 +8,8 @@ import { HelperService } from '../../services/helper.service';
 })
 export class TimerComponent implements OnInit {
   @Input() start: Date;
-  @Input() interval: number;
   @Input() update: boolean;
   @Input() clickable: boolean;
-  @Output() elapsed = new EventEmitter();
 
   value = 0;
 
@@ -27,11 +25,7 @@ export class TimerComponent implements OnInit {
 
   compute(): void {
     if(this.update) {
-      this.value = this.helperService.getSecondsElapsed(this.start);
-
-      if(this.value > 0 && this.value % this.interval === 0) {
-        this.elapsed.emit();
-      }
+      this.value = this.start ? this.helperService.getSecondsElapsed(this.start) : 0;
     }
   }
 }

--- a/src/app/shared/services/color.service.ts
+++ b/src/app/shared/services/color.service.ts
@@ -13,7 +13,8 @@ export class ColorService {
       case relativeDelay === 0: return 'color-on-time';
       case relativeDelay < 3: return 'color-slightly-late';
       case relativeDelay < 5: return 'color-late';
-      default: return 'color-very-late';
+      case relativeDelay < 10: return 'color-very-late';
+      default: return 'color-cancelled';
     }
   }
 }

--- a/src/app/shared/services/date-time.service.ts
+++ b/src/app/shared/services/date-time.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { differenceInSeconds } from 'date-fns';
+import { differenceInSeconds, differenceInMinutes } from 'date-fns';
 
 @Injectable({
   providedIn: 'root'
@@ -9,5 +9,9 @@ export class DateTimeService {
 
   getSecondsElapsed(start: Date): number {
     return differenceInSeconds(new Date(), start);
+  }
+
+  getMinutesFromNow(date: Date): number {
+    return differenceInMinutes(date, new Date());
   }
 }

--- a/src/app/shared/services/date-time.service.ts
+++ b/src/app/shared/services/date-time.service.ts
@@ -4,7 +4,7 @@ import { differenceInSeconds } from 'date-fns';
 @Injectable({
   providedIn: 'root'
 })
-export class HelperService {
+export class DateTimeService {
   constructor() { }
 
   getSecondsElapsed(start: Date): number {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -79,8 +79,8 @@
   --color-departed: #92949c;
   --color-on-time: #02a342;
   --color-cancelled: #eb445a;
-  --color-slightly-early: #40e0d0;
-  --color-early: #00bfff;
+  --color-slightly-early: #0ec9b8;
+  --color-early: #09a9ed;
   --color-slightly-late: #a8a803;
   --color-late: #edb607;
   --color-very-late: #ff7b00;


### PR DESCRIPTION
- Fixed various auto update and timer display issues on the departure cards that occurred after the previous version.
- The departure time on the quick search card is now auto-updated more reliably. It is now updated whenever the set time is behind the current time, eliminating instances where the departure time might be outdated after reopening the app.
- Delay colors have been adjusted slightly.
- Departures with a delay of more than ten minutes are now shown in red.
- The settings page now includes a build number.